### PR TITLE
Addition: Parsing Config Settings from a TOML file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 app.egg-info
 **/__pycache__/
+config.toml

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ the supported arguments as of now are:
 2. To create your own configuration file, run the following command:
 
    ```sh
-   cp config.toml.example addcom_config.toml
+   cp config.toml.example ~/addcom_config.toml
    ```
 
    

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ the supported arguments as of now are:
 
 `--base-url` / `u` - If you decide to use a custom API endpoint, make sure to obtain an API key and specify a Large Language Model supported by the API of your choice.
 
+`Windows Path Handling`: When specifying the location of the context file, using standard Windows path single backslashes (\) can cause parsing errors, as tomllib treats those as escape characters. Windows users should specify paths with double backslashes (e.g., context = "examples\\commented.py" instead of context = "examples\commented.py").
+
 #### Example: using OpenRouter API as base URL
 
 ```cmd

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ You can add comments to one or multiple source code files. Just type addcom and 
 
 The functionality to provide arguments via a TOML file has been provided as well, you can find more information about a TOML file [here](https://toml.io/en/) 
 
-if you want to pre-define the arguments for the CLI tool, you can add the arguments in the `config.toml` file as well
+if you want to pre-define the arguments for the CLI tool, you can add the arguments in the `addcom_config.toml` file as well in the home directory
+
+this will only work if you have `addcom_config.toml` in the home directory
 the supported arguments as of now are:
 
 
@@ -93,8 +95,9 @@ the supported arguments as of now are:
 2. To create your own configuration file, run the following command:
 
    ```sh
-   cp config.toml.example config.toml
+   cp config.toml.example addcom_config.toml
    ```
+
    
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ You can add comments to one or multiple source code files. Just type addcom and 
 | `--base-url`    | `-u`     | TEXT   | Specify base URL for the API                          | None    |
 | `--model `      | `-o`     | TEXT   | Specify a LLM to use for comment generation           | None    |
 
+
+## Configuration via TOML file
+
+The functionality to provide arguments via a TOML file has been provided as well, you can find more information about a TOML file [here](https://toml.io/en/) 
+
+if you want to pre-define the arguments for the CLI tool, you can add the arguments in the `config.toml` file as well
+the supported arguments as of now are:
+
+
+`model` - specifies the model of groq to be used
+`stream` - can be set to "true" or "false"
+`api_key` - specifies the api_key to be used for the API
+`context` - specifies the context file to provide 
+
+1. A sample configuration file `config.toml.example` is provided in the repository.
+2. To create your own configuration file, run the following command:
+
+   ```sh
+   cp config.toml.example config.toml
+   ```
+   
+
 ### Notes
 `--output` / `-o` - If multiple files are specified, the commented source code from all files will be combined and saved into a single output file.
 

--- a/app/core/file_operations.py
+++ b/app/core/file_operations.py
@@ -28,15 +28,15 @@ def write_to_output_file(output: str, commented_content: str):
         print(f"Error writing to file {output}: {e}", file=sys.stderr)
 
 def find_toml():
-    for root,dirs,files in os.walk(".",topdown=False):
-        for file in files:
-            if file.endswith(".toml"):
-                return os.path.join(root,file)
+    home_dir = os.path.expanduser("~")
+    for file in os.listdir(home_dir):
+        if file == "addcom_config.toml":
+            return os.path.join(home_dir,file)
     print("Config File Wasn't Found")
     return None
 
 def read_toml(file: str):
-    if not os.path.isfile(file) or not file.endswith(".toml"):
+    if not os.path.isfile(file):
         print(f"File not found: {file}", file=sys.stderr)
         return None
 

--- a/app/core/file_operations.py
+++ b/app/core/file_operations.py
@@ -43,5 +43,17 @@ def read_toml(file: str):
     with open(file,"rb") as f:
         data = tomllib.load(f)
         return data
+    
+def get_config():
+    toml_file =find_toml()
+
+    if toml_file:
+        config_data = read_toml(toml_file)
+        return config_data
+
+    return None
+    
+    
+    
 
 

--- a/app/core/file_operations.py
+++ b/app/core/file_operations.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import tomllib
 
 
 def load_contents(file_path: str):
@@ -33,3 +34,14 @@ def find_toml():
                 return os.path.join(root,file)
     print("Config File Wasn't Found")
     return None
+
+def read_toml(file: str):
+    if not os.path.isfile(file) or not file.endswith(".toml"):
+        print(f"File not found: {file}", file=sys.stderr)
+        return None
+
+    with open(file,"rb") as f:
+        data = tomllib.load(f)
+        return data
+
+

--- a/app/core/file_operations.py
+++ b/app/core/file_operations.py
@@ -25,3 +25,11 @@ def write_to_output_file(output: str, commented_content: str):
             
     except IOError as e:
         print(f"Error writing to file {output}: {e}", file=sys.stderr)
+
+def find_toml():
+    for root,dirs,files in os.walk(".",topdown=False):
+        for file in files:
+            if file.endswith(".toml"):
+                return os.path.join(root,file)
+    print("Config File Wasn't Found")
+    return None

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,12 @@
 import typer
-from rich import print
 from rich.markup import escape
+from rich import print
 from typing_extensions import Annotated
 from typing import Optional
 from app.core.callbacks import version_callback, context_callback
-from app.core.file_operations import load_contents, write_to_output_file
+from app.core.file_operations import load_contents, write_to_output_file,get_config
 from app.core.api import generate_comments
+
 
 # Create Typer instance
 app = typer.Typer()
@@ -61,6 +62,15 @@ def add_comments(
     """
     Add comments to each of the provided files.
     """
+    config_data = get_config()
+
+    context = context or config_data.get("context")
+    api_key = api_key or config_data.get("api_key")
+    stream = stream or config_data.get("stream",False)
+    model = model or config_data.get("model")
+
+    
+
     for file_path in file_paths:
         content = load_contents(file_path)
 

--- a/app/main.py
+++ b/app/main.py
@@ -64,10 +64,11 @@ def add_comments(
     """
     config_data = get_config()
 
-    context = context or config_data.get("context")
-    api_key = api_key or config_data.get("api_key")
-    stream = stream or config_data.get("stream",False)
-    model = model or config_data.get("model")
+    if config_data != None:
+        context = context or config_data.get("context")
+        api_key = api_key or config_data.get("api_key")
+        stream = stream or config_data.get("stream",False)
+        model = model or config_data.get("model")
 
     
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,7 @@
+context = "randomContextFile.py"
+api_key = "api_key_value"
+stream = true
+model = "llama3-8b-8192"
+
+
+


### PR DESCRIPTION
This pull request adds the feature that allows the user to specify the CLI arguments in a TOML config file and resolves issue #8 

Checklist 
- [x] Make the function to find and read the TOML file
- [x] Make the functionality to load and use the variables from the TOML while the CLI binary is being called
- [x] Documentation has been updated to reflect changes
- [x] Example TOML file has been added


